### PR TITLE
Bold Live Demo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Welcome to the [PWABuilder](https://www.pwabuilder.com/) pwa-starter! Looking to
 - Includes the [PWABuilder pwa-install component](https://github.com/pwa-builder/pwa-install#pwa-install) for an app store like PWA install experience.
 - [Workbox](https://developers.google.com/web/tools/workbox/) for service workers along with the [PWABuilder pwa-update component](https://github.com/pwa-builder/pwa-update#pwa-update) to give your PWA a great offline experience.
 
-** [Live Demo](https://pwa-starter-demo.glitch.me/) **
+**[Live Demo](https://pwa-starter-demo.glitch.me/)**
 
 ## Getting Started
 


### PR DESCRIPTION
I believe that the Live Demo in the README was intended to be bolded. I removed the whitespace surrounding the markdown to reflect this.