### PR TITLE
feat(): use static-web-apps cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ With it you get an app that:
 - Using the fluent Web Components, you can build native looking PWAs on Windows
 - Has everything needed to be installable in the browser
 - Is ready to be package for the app stores using [PWABuilder](https://www.pwabuilder.com)
+- Uses the [Azure Static Web Apps CLI](https://azure.github.io/static-web-apps-cli) which enables emulating your production environment locally, and gets you ready for deploying to Azure Static Web Apps!
 
 and all with just a few button clicks 😊.
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "A starter kit for building PWAs!",
   "main": "index.js",
   "scripts": {
-    "dev": "vite --open",
+    "dev-server": "vite --open",
+    "dev": "npx @azure/static-web-apps-cli start http://localhost:3000 --run 'npm run dev-server'",
     "dev-task": "vite",
+    "deploy": " npx @azure/static-web-apps-cli login --no-use-keychain && npx @azure/static-web-apps-cli deploy",
     "build": "tsc && vite build",
-    "start": "npm run build && vite preview",
+    "start": "npm run dev",
     "start-remote": "vite --host"
   },
   "author": "",

--- a/swa-cli.config.json
+++ b/swa-cli.config.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://aka.ms/azure/static-web-apps-cli/schema",
+  "configurations": {
+    "pwa-starter": {
+      "appLocation": ".",
+      "outputLocation": "dist",
+      "appBuildCommand": "npm run build --if-present",
+      "run": "npm start",
+      "appDevserverUrl": "http://localhost:3000"
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/pwa-builder/PWABuilder/issues/3153
This PR adds:

- The dev command, npm run dev  (or npm start) now uses the Azure Static Web Apps CLI
- New command in the package.json, deploy, for deploying with the Azure Static Web Apps CLI