### PR TITLE
Update header.ts

### DIFF
--- a/src/components/header.ts
+++ b/src/components/header.ts
@@ -68,7 +68,7 @@ export class AppHeader extends LitElement {
 
         <div id="back-button-block">
           ${this.enableBack ? html`<sl-button href="${(import.meta as any).env.BASE_URL}">
-            Back
+            Home
           </sl-button>` : null}
 
           <h1>${this.title}</h1>


### PR DESCRIPTION
This button will always take you back to the 'home page' of the PWA so it should not called a 'Back' button as this will confuse developers that build pages deeper than the top level and expect the <app-header> to provide a back button and not a home button.