### PR TITLE
fix: router types and cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@shoelace-style/shoelace": "^2.4.0",
-        "@thepassle/app-tools": "^0.9.0",
+        "@thepassle/app-tools": "^0.9.9",
         "lit": "^2.7.2",
         "urlpattern-polyfill": "^7.0.0",
         "workbox-build": "^6.5.2",
@@ -2079,9 +2079,9 @@
       }
     },
     "node_modules/@thepassle/app-tools": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@thepassle/app-tools/-/app-tools-0.9.0.tgz",
-      "integrity": "sha512-o/i0tJZM8jUjQ0ADRfPlEkf05tkwNawh273Qmmtzx6PEDJ8WuRSTRXJgiJj2NKs8mGU9HOO9H1rVo3dfQjWK9A=="
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@thepassle/app-tools/-/app-tools-0.9.9.tgz",
+      "integrity": "sha512-HiTHYXyK8etO9RvRbIBHd/hienOsBzVE1K20DSTLK4kEJwUuRNw9xYyiYoPpGTKYptGmPTVKOs52GsqzlQgkng=="
     },
     "node_modules/@types/estree": {
       "version": "0.0.39",
@@ -5704,9 +5704,9 @@
       }
     },
     "@thepassle/app-tools": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@thepassle/app-tools/-/app-tools-0.9.0.tgz",
-      "integrity": "sha512-o/i0tJZM8jUjQ0ADRfPlEkf05tkwNawh273Qmmtzx6PEDJ8WuRSTRXJgiJj2NKs8mGU9HOO9H1rVo3dfQjWK9A=="
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@thepassle/app-tools/-/app-tools-0.9.9.tgz",
+      "integrity": "sha512-HiTHYXyK8etO9RvRbIBHd/hienOsBzVE1K20DSTLK4kEJwUuRNw9xYyiYoPpGTKYptGmPTVKOs52GsqzlQgkng=="
     },
     "@types/estree": {
       "version": "0.0.39",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "@shoelace-style/shoelace": "^2.4.0",
-    "@thepassle/app-tools": "^0.9.0",
+    "@thepassle/app-tools": "^0.9.9",
     "lit": "^2.7.2",
     "urlpattern-polyfill": "^7.0.0",
     "workbox-build": "^6.5.2",

--- a/router.d.ts
+++ b/router.d.ts
@@ -1,3 +1,0 @@
-declare module '@thepassle/app-tools/router.js';
-declare module '@thepassle/app-tools/router/plugins/lazy.js';
-declare module '@thepassle/app-tools/router/plugins/title.js';

--- a/src/app-index.ts
+++ b/src/app-index.ts
@@ -8,26 +8,18 @@ import { router } from './router';
 
 @customElement('app-index')
 export class AppIndex extends LitElement {
-  static get styles() {
-    return css`
-      main {
-        padding-left: 16px;
-        padding-right: 16px;
-        padding-bottom: 16px;
-      }
-    `;
-  }
-
-  constructor() {
-    super();
-  }
+  static styles = css`
+    main {
+      padding-left: 16px;
+      padding-right: 16px;
+      padding-bottom: 16px;
+    }
+  `;
 
   firstUpdated() {
     router.addEventListener('route-changed', () => {
       if ("startViewTransition" in document) {
-        return (document as any).startViewTransition(() => {
-          this.requestUpdate();
-        });
+        (document as any).startViewTransition(() => this.requestUpdate());
       }
       else {
         this.requestUpdate();

--- a/src/components/header.ts
+++ b/src/components/header.ts
@@ -9,59 +9,53 @@ export class AppHeader extends LitElement {
 
   @property({ type: Boolean}) enableBack: boolean = false;
 
-  static get styles() {
-    return css`
+  static styles = css`
+    header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background: var(--app-color-primary);
+      color: white;
+      height: 4em;
+      padding-left: 16px;
+      padding-top: 12px;
+
+      position: fixed;
+      left: env(titlebar-area-x, 0);
+      top: env(titlebar-area-y, 0);
+      height: env(titlebar-area-height, 50px);
+      width: env(titlebar-area-width, 100%);
+      -webkit-app-region: drag;
+    }
+
+    header h1 {
+      margin-top: 0;
+      margin-bottom: 0;
+      font-size: 20px;
+      font-weight: bold;
+    }
+
+    nav a {
+      margin-left: 10px;
+    }
+
+    #back-button-block {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      width: 12em;
+    }
+
+    @media(prefers-color-scheme: light) {
       header {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        background: var(--app-color-primary);
-        color: white;
-        height: 4em;
-        padding-left: 16px;
-        padding-top: 12px;
-
-        position: fixed;
-        left: env(titlebar-area-x, 0);
-        top: env(titlebar-area-y, 0);
-        height: env(titlebar-area-height, 50px);
-        width: env(titlebar-area-width, 100%);
-        -webkit-app-region: drag;
-      }
-
-      header h1 {
-        margin-top: 0;
-        margin-bottom: 0;
-        font-size: 20px;
-        font-weight: bold;
+        color: black;
       }
 
       nav a {
-        margin-left: 10px;
+        color: initial;
       }
-
-      #back-button-block {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        width: 12em;
-      }
-
-      @media(prefers-color-scheme: light) {
-        header {
-          color: black;
-        }
-
-        nav a {
-          color: initial;
-        }
-      }
-    `;
-  }
-
-  constructor() {
-    super();
-  }
+    }
+  `;
 
   render() {
     return html`

--- a/src/pages/app-about/app-about.ts
+++ b/src/pages/app-about/app-about.ts
@@ -16,10 +16,6 @@ export class AppAbout extends LitElement {
     styles
   ]
 
-  constructor() {
-    super();
-  }
-
   render() {
     return html`
       <app-header ?enableBack="${true}"></app-header>
@@ -39,7 +35,7 @@ export class AppAbout extends LitElement {
               href="https://docs.microsoft.com/en-us/microsoft-edge/progressive-web-apps-chromium/how-to/handle-files">these
               docs</a> to learn more about the advanced features that you can use in your PWA</p>
         </sl-card>
-  </main>
+      </main>
     `;
   }
 }

--- a/src/pages/app-home.ts
+++ b/src/pages/app-home.ts
@@ -14,52 +14,46 @@ export class AppHome extends LitElement {
   // check out this link https://lit.dev/docs/components/properties/
   @property() message = 'Welcome!';
 
-  static get styles() {
-    return [
-      styles,
-      css`
+  static styles = [
+    styles,
+    css`
+    #welcomeBar {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      flex-direction: column;
+    }
+
+    #welcomeCard,
+    #infoCard {
+      padding: 18px;
+      padding-top: 0px;
+    }
+
+    sl-card::part(footer) {
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    @media(min-width: 750px) {
+      sl-card {
+        width: 70vw;
+      }
+    }
+
+
+    @media (horizontal-viewport-segments: 2) {
       #welcomeBar {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        flex-direction: column;
+        flex-direction: row;
+        align-items: flex-start;
+        justify-content: space-between;
       }
 
-      #welcomeCard,
-      #infoCard {
-        padding: 18px;
-        padding-top: 0px;
+      #welcomeCard {
+        margin-right: 64px;
       }
-
-      sl-card::part(footer) {
-        display: flex;
-        justify-content: flex-end;
-      }
-
-      @media(min-width: 750px) {
-        sl-card {
-          width: 70vw;
-        }
-      }
-
-
-      @media (horizontal-viewport-segments: 2) {
-        #welcomeBar {
-          flex-direction: row;
-          align-items: flex-start;
-          justify-content: space-between;
-        }
-
-        #welcomeCard {
-          margin-right: 64px;
-        }
-      }
-    `];
-  }
-
-  constructor() {
-    super();
-  }
+    }
+  `];
 
   async firstUpdated() {
     // this method is a lifecycle even in lit

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
       "noUnusedParameters": true,
       "noImplicitReturns": true,
       "noFallthroughCasesInSwitch": true,
-      "moduleResolution": "node",
+      "moduleResolution": "bundler",
       "allowSyntheticDefaultImports": true,
       "experimentalDecorators": true,
       "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Hey there :)

I fixed the exported types for most of app-tools, so the router is now typed, and you dont need the manual router.d.ts anymore

I also took the liberty to clean up some other things, I noticed there were some unnecessary constructors, and I refactored the `static get styles()` to the more modern `static styles`