### PR TITLE
fix(pages-build): add slashes around base value

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         run: sed -i 's@"/"@"/${{ github.event.repository.name }}/"@g' ./public/manifest.json && cat ./public/manifest.json
 
       - name: Vite Build
-        run: npm run build -- --base=${{ github.event.repository.name }}
+        run: npm run build -- --base=/${{ github.event.repository.name }}/
 
       - name: Redirect 404 to Index for SPA
         run: cp dist/index.html dist/404.html


### PR DESCRIPTION
This PR fixes routing for [GitHub Pages deployments](https://docs.pwabuilder.com/#/starter/publish?id=github-pages). Without this change, the router doesn't work and the app crashes.