### PR TITLE
feat: upgrade shoelace-style/shoelace and added icon support by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,10 +31,15 @@
 
   <!-- light mode and dark mode CSS -->
   <link rel="stylesheet" media="(prefers-color-scheme:light)"
-    href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.73/dist/themes/light.css">
+    href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.16.0/dist/themes/light.css">
   <link rel="stylesheet" media="(prefers-color-scheme:dark)"
-    href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.73/dist/themes/dark.css"
+    href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.16.0/dist/themes/dark.css"
     onload="document.documentElement.classList.add('sl-theme-dark');">
+
+  <script type="module">
+    import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.js';
+    setBasePath('https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.16.0/cdn/');
+  </script>
 
   <script type="module" src="/src/app-index.ts"></script>
 </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@shoelace-style/shoelace": "^2.15.0",
+        "@shoelace-style/shoelace": "^2.16.0",
         "@thepassle/app-tools": "^0.9.12",
         "lit": "^3.1.2",
         "urlpattern-polyfill": "^10.0.0",
@@ -2269,9 +2269,10 @@
       "integrity": "sha512-Hf45HeO+vdQblabpyZOTxJ4ZeZsmIUYXXPmoYrrR4OJ5OKxL+bhMz5mK8JXgl7HsoEowfz7+e248UGi861de9Q=="
     },
     "node_modules/@shoelace-style/shoelace": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@shoelace-style/shoelace/-/shoelace-2.15.0.tgz",
-      "integrity": "sha512-Lcg938Y8U2VsHqIYewzlt+H1rbrXC4GRSUkTJgXyF8/0YAOlI+srd5OSfIw+/LYmwLP2Peyh398Kae/6tg4PDA==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/shoelace/-/shoelace-2.16.0.tgz",
+      "integrity": "sha512-OV4XYAAZv0OfOR4RlpxCYOn7pH8ETIL8Pkh5hFvIrL+BN4/vlBLoeESYDU2tB/f9iichu4cfwdPquJITmKdY1w==",
+      "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "^4.0.2",
         "@floating-ui/dom": "^1.5.3",
@@ -6066,9 +6067,9 @@
       "integrity": "sha512-Hf45HeO+vdQblabpyZOTxJ4ZeZsmIUYXXPmoYrrR4OJ5OKxL+bhMz5mK8JXgl7HsoEowfz7+e248UGi861de9Q=="
     },
     "@shoelace-style/shoelace": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@shoelace-style/shoelace/-/shoelace-2.15.0.tgz",
-      "integrity": "sha512-Lcg938Y8U2VsHqIYewzlt+H1rbrXC4GRSUkTJgXyF8/0YAOlI+srd5OSfIw+/LYmwLP2Peyh398Kae/6tg4PDA==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/shoelace/-/shoelace-2.16.0.tgz",
+      "integrity": "sha512-OV4XYAAZv0OfOR4RlpxCYOn7pH8ETIL8Pkh5hFvIrL+BN4/vlBLoeESYDU2tB/f9iichu4cfwdPquJITmKdY1w==",
       "requires": {
         "@ctrl/tinycolor": "^4.0.2",
         "@floating-ui/dom": "^1.5.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@shoelace-style/shoelace": "^2.15.0",
+    "@shoelace-style/shoelace": "^2.16.0",
     "@thepassle/app-tools": "^0.9.12",
     "lit": "^3.1.2",
     "urlpattern-polyfill": "^10.0.0",

--- a/src/pages/app-home.ts
+++ b/src/pages/app-home.ts
@@ -98,7 +98,10 @@ export class AppHome extends LitElement {
             </p>
 
             ${'share' in navigator
-              ? html`<sl-button slot="footer" variant="primary" @click="${this.share}">Share this Starter!</sl-button>`
+              ? html`<sl-button slot="footer" variant="default" @click="${this.share}">
+                        <sl-icon slot="prefix" name="share"></sl-icon>
+                        Share this Starter!
+                      </sl-button>`
               : null}
           </sl-card>
 


### PR DESCRIPTION
### Changes

- Upgraded shoelace-style/shoelace in both package.json and the link html tags.
- Some components rely on assets (icons, images, etc.) and Shoelace needs to know where they’re located, so added this setup: https://shoelace.style/getting-started/installation#setting-the-base-path
- Modified the share button CTA to include the icon as an "example".

![image](https://github.com/user-attachments/assets/15a1cc29-8209-42a5-8e63-2e2076e09e66)


### Motivation
People may have some difficult to use the icons and other components, and especially how to properly setup it, example this person in discord: https://discord.com/channels/930156205542883409/1269757245910945964